### PR TITLE
Generator on windows fixed using Path.DirectorySeparatorChar

### DIFF
--- a/Assets/ECS/ECSEditor/Generator/Generator.cs
+++ b/Assets/ECS/ECSEditor/Generator/Generator.cs
@@ -151,7 +151,7 @@ namespace ME.ECSEditor {
             var itemStr2 = Generator.CONTENT_ITEM2;
             var itemStr3 = Generator.CONTENT_ITEM3;
 
-            var splittedMain = dir.Split('/');
+            var splittedMain = dir.Split(Path.DirectorySeparatorChar);
             var asmNameMain = splittedMain[splittedMain.Length - 1];
 
             var listEntities = new List<System.Type>();
@@ -169,7 +169,7 @@ namespace ME.ECSEditor {
                 var asmNamePath = System.IO.Path.GetDirectoryName(asmPath);
                 if (System.IO.Directory.Exists(asmNamePath) == false) continue;
 
-                var splitted = asmNamePath.Split('/');
+                var splitted = asmNamePath.Split(Path.DirectorySeparatorChar);
                 var asmName = splitted[splitted.Length - 1];
 
                 var assemblies = System.AppDomain.CurrentDomain.GetAssemblies();


### PR DESCRIPTION
Using `Path.DirectorySeparatorChar` when handling paths splits to avoid the "/" and "\\" difference between unix based and windows os

Not sure if there is another place where it should be used too, at least generator seems to work fine now